### PR TITLE
2단계 - 지하철 구간 추가 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured:4.2.0'
 
     runtimeOnly 'com.h2database:h2'
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok:")
 }
 
 test {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -65,11 +65,12 @@ public class LineService {
     }
 
     @Transactional
-    public void addSection(Long lineId, SectionRequest sectionRequest) {
+    public LineResponse addSection(Long lineId, SectionRequest sectionRequest) {
         Station upStation = stationService.findById(sectionRequest.getUpStationId());
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
         line.addSection(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+        return createLineResponse(line);
     }
 
     private LineResponse createLineResponse(Line line) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -102,10 +102,7 @@ public class LineService {
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
         Station station = stationService.findById(stationId);
 
-        if (!line.getLastSection().getDownStation().equals(station)) {
-            throw new IllegalArgumentException("마지막 구간만 삭제할 수 있습니다.");
-        }
-
+        line.validateRemoveSection(station);
         line.removeSection(line.getLastSection());
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -69,8 +69,7 @@ public class LineService {
         Station upStation = stationService.findById(sectionRequest.getUpStationId());
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
-
-        line.getSections().add(new Section(line, upStation, downStation, sectionRequest.getDistance()));
+        line.addSection(new Section(line, upStation, downStation, sectionRequest.getDistance()));
     }
 
     private LineResponse createLineResponse(Line line) {
@@ -103,10 +102,10 @@ public class LineService {
         Line line = lineRepository.findById(lineId).orElseThrow(IllegalArgumentException::new);
         Station station = stationService.findById(stationId);
 
-        if (!line.getSections().get(line.getSections().size() - 1).getDownStation().equals(station)) {
-            throw new IllegalArgumentException();
+        if (!line.getLastSection().getDownStation().equals(station)) {
+            throw new IllegalArgumentException("마지막 구간만 삭제할 수 있습니다.");
         }
 
-        line.getSections().remove(line.getSections().size() - 1);
+        line.removeSection(line.getLastSection());
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -5,6 +5,12 @@ public class SectionRequest {
     private Long downStationId;
     private int distance;
 
+    public SectionRequest(long upStationId, long downStationId, int distance) {
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
     public Long getUpStationId() {
         return upStationId;
     }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -52,6 +52,10 @@ public class Line {
         return sections;
     }
 
+    public Section getLastSection() {
+        return getSections().get(sections.size()-1);
+    }
+
     public void addSection(Section section) {
         this.sections.add(section);
     }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -71,4 +71,10 @@ public class Line {
     public void removeSection(Section section) {
         this.sections.remove(section);
     }
+
+    public void validateRemoveSection(Station station) {
+        if (!getLastSection().getDownStation().equals(station)) {
+            throw new IllegalArgumentException("마지막 구간만 삭제할 수 있습니다.");
+        }
+    }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -3,6 +3,7 @@ package nextstep.subway.domain;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 public class Line {
@@ -49,5 +50,21 @@ public class Line {
 
     public List<Section> getSections() {
         return sections;
+    }
+
+    public void addSection(Section section) {
+        this.sections.add(section);
+    }
+
+    public List<Station> getStations() {
+        return this.sections.stream()
+            .map(Section::getStationList)
+            .flatMap(List::stream)
+            .distinct()
+            .collect(Collectors.toList());
+    }
+
+    public void removeSection(Section section) {
+        this.sections.remove(section);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,11 +1,19 @@
 package nextstep.subway.domain;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Line {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -13,47 +21,20 @@ public class Line {
     private String name;
     private String color;
 
-    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
-    private List<Section> sections = new ArrayList<>();
-
-    public Line() {
-    }
+    @Embedded
+    private Sections sections = new Sections();
 
     public Line(String name, String color) {
         this.name = name;
         this.color = color;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getColor() {
-        return color;
-    }
-
-    public void setColor(String color) {
-        this.color = color;
-    }
-
     public List<Section> getSections() {
-        return sections;
+        return sections.getSections();
     }
 
     public Section getLastSection() {
-        return getSections().get(sections.size()-1);
+        return getSections().get(sections.getSize()-1);
     }
 
     public void addSection(Section section) {
@@ -61,11 +42,7 @@ public class Line {
     }
 
     public List<Station> getStations() {
-        return this.sections.stream()
-            .map(Section::getStationList)
-            .flatMap(List::stream)
-            .distinct()
-            .collect(Collectors.toList());
+        return sections.getStations();
     }
 
     public void removeSection(Section section) {

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,6 +1,7 @@
 package nextstep.subway.domain;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 public class Section {
@@ -51,5 +52,9 @@ public class Section {
 
     public int getDistance() {
         return distance;
+    }
+
+    public List<Station> getStationList() {
+        return List.of(upStation, downStation);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -44,6 +44,15 @@ public class Sections {
         if (containsAllStation(section)) {
             throw new IllegalArgumentException("상행역과 하행역이 이미 등록되어있습니다.");
         }
+
+        // 상행역과 하행역 모두 등록되어있지 않으면 예외 발생
+        if (notContainsAllStation(section)) {
+            throw new IllegalArgumentException("상행역과 하행역이 모두 등록되어있지 않습니다.");
+        }
+    }
+
+    private boolean notContainsAllStation(Section section) {
+        return !getStations().contains(section.getUpStation()) && !getStations().contains(section.getDownStation());
     }
 
     private boolean containsAllStation(Section section) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -1,0 +1,56 @@
+package nextstep.subway.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor
+@Embeddable
+@Getter
+public class Sections {
+
+    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+    private final List<Section> sections = new ArrayList<>();
+
+    public int getSize() {
+        return sections.size();
+    }
+
+    public List<Station> getStations() {
+        return this.sections.stream()
+                .map(Section::getStationList)
+                .flatMap(List::stream)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    public void add(Section section) {
+        validateAdd(section);
+
+        sections.add(section);
+    }
+
+    private void validateAdd(Section section) {
+        Assert.isTrue(section != null, "section은 null일 수 없습니다.");
+
+        // 상행역과 하행역 모두 등록되어있으면 예외 발생
+        if (containsAllStation(section)) {
+            throw new IllegalArgumentException("상행역과 하행역이 이미 등록되어있습니다.");
+        }
+    }
+
+    private boolean containsAllStation(Section section) {
+        return getStations().contains(section.getUpStation()) && getStations().contains(section.getDownStation());
+    }
+
+    public void remove(Section section) {
+        sections.remove(section);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -34,7 +34,17 @@ public class Sections {
 
         if (isUpTerminal(section)) {
             sections.add(0, section);
+            return;
         }
+
+        if (isDownTerminal(section)) {
+            sections.add(section);
+            return;
+        }
+    }
+
+    private boolean isDownTerminal(Section section) {
+        return getDownTerminal().equals(section.getUpStation());
     }
 
     private boolean isUpTerminal(Section section) {
@@ -43,6 +53,10 @@ public class Sections {
 
     private Station getUpTerminal() {
         return sections.get(0).getUpStation();
+    }
+
+    private Station getDownTerminal() {
+        return sections.get(sections.size()-1).getDownStation();
     }
 
     private void validateAdd(Section section) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -48,7 +48,15 @@ public class Sections {
                 .findFirst()
                 .orElse(0);
 
+        validDistance(section, index);
+
         this.sections.add(index, section);
+    }
+
+    private void validDistance(Section section, int index) {
+        if(this.sections.get(index).getDistance() <= section.getDistance()) {
+            throw new IllegalArgumentException("등록하려는 구간 길이가 기존 구간 길이보다 클 수 없습니다.");
+        }
     }
 
     private boolean isDownTerminal(Section section) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -10,6 +10,7 @@ import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @NoArgsConstructor
 @Embeddable
@@ -41,6 +42,13 @@ public class Sections {
             sections.add(section);
             return;
         }
+
+        int index = IntStream.range(0, sections.size())
+                .filter(i-> sections.get(i).getDownStation().equals(section.getUpStation()))
+                .findFirst()
+                .orElse(0);
+
+        this.sections.add(index, section);
     }
 
     private boolean isDownTerminal(Section section) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -24,17 +24,25 @@ public class Sections {
     }
 
     public List<Station> getStations() {
-        return this.sections.stream()
-                .map(Section::getStationList)
-                .flatMap(List::stream)
-                .distinct()
-                .collect(Collectors.toList());
+        List<Station> stations = this.sections.stream().map(Section::getDownStation).collect(Collectors.toList());
+        stations.add(0, getUpTerminal());
+        return stations;
     }
 
     public void add(Section section) {
         validateAdd(section);
 
-        sections.add(section);
+        if (isUpTerminal(section)) {
+            sections.add(0, section);
+        }
+    }
+
+    private boolean isUpTerminal(Section section) {
+        return getUpTerminal().equals(section.getDownStation());
+    }
+
+    private Station getUpTerminal() {
+        return sections.get(0).getUpStation();
     }
 
     private void validateAdd(Section section) {

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -1,29 +1,24 @@
 package nextstep.subway.domain;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Station {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
 
-    public Station() {
-    }
-
     public Station(String name) {
         this.name = name;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
     }
 }

--- a/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/ControllerExceptionHandler.java
@@ -1,6 +1,8 @@
 package nextstep.subway.ui;
 
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,6 +11,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class ControllerExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Void> handleIllegalArgsException(DataIntegrityViolationException e) {
+        return ResponseEntity.badRequest().build();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Void> handleBadRequest(IllegalArgumentException e) {
         return ResponseEntity.badRequest().build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -50,9 +50,8 @@ public class LineController {
     }
 
     @PostMapping("/{lineId}/sections")
-    public ResponseEntity<Void> addSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
-        lineService.addSection(lineId, sectionRequest);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<LineResponse> addSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
+        return ResponseEntity.ok().body(lineService.addSection(lineId, sectionRequest));
     }
 
     @DeleteMapping("/{lineId}/sections")

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -53,7 +53,12 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             @DisplayName("새로운 역을 상행 종점으로 등록")
             @Test
             void 상행_종점_등록 () {
+                // when
+                ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(삼성역, 강남역));
 
+                // then
+                assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(삼성역, 강남역, 양재역);
             }
 
             /**

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -68,7 +68,12 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             @DisplayName("새로운 역을 하행 종점으로 등록")
             @Test
             void 하행_종점_등록 () {
+                // when
+                ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 삼성역));
 
+                // then
+                assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 삼성역);
             }
 
             /**

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -4,6 +4,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
@@ -35,21 +36,76 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
     }
 
-    /**
-     * When 지하철 노선에 새로운 구간 추가를 요청 하면
-     * Then 노선에 새로운 구간이 추가된다
-     */
-    @DisplayName("지하철 노선에 구간을 등록")
-    @Test
-    void addLineSection() {
-        // when
-        Long 정자역 = 지하철역_생성_요청("정자역").jsonPath().getLong("id");
-        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(양재역, 정자역));
+    @Nested
+    class 구간_등록 {
 
-        // then
-        ExtractableResponse<Response> response = 지하철_노선_조회_요청(신분당선);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 양재역, 정자역);
+        @Nested
+        class 성공 {
+            /**
+             * when 새로운 역을 상행 종점으로 구간 등록하면
+             * then 새로운 역이 상행 종점으로 등록된다.
+             */
+            @DisplayName("새로운 역을 상행 종점으로 등록")
+            @Test
+            void 상행_종점_등록 () {
+
+            }
+
+            /**
+             * when 새로운 역을 하행 종점으로 구간 등록하면
+             * then 새로운 역이 하행 종점으로 등록된다.
+             */
+            @DisplayName("새로운 역을 하행 종점으로 등록")
+            @Test
+            void 하행_종점_등록 () {
+
+            }
+
+            /**
+             * when 기존 구간에 새로운 역 등록하면
+             * then 새로운 역이 등록된다.
+             */
+            @DisplayName("역 사이에 새로운 역 등록")
+            @Test
+            void 역사이_새로운역_등록 () {
+
+            }
+        }
+
+        @Nested
+        class 실패 {
+            /**
+             * when 역 사이에 새로운 역 등록할 경우
+             * when 기존 역 사이 길이보다 크거나 같은 구간을 등록하면
+             * then 예외가 발생한다.
+             */
+            @DisplayName("기존 역 사이 길이보다 크거나 같으면 예외 발생")
+            @Test
+            void 구간_길이_예외 () {
+
+            }
+
+            /**
+             * when 이미 모두 등록되어있는 상행역과 하행역을 등록하면
+             * then 예외가 발생한다.
+             */
+            @DisplayName("상행역과 하행역 모두 등록되어있으면 예외 발생")
+            @Test
+            void 상행역_하행역_모두_등록_예외 () {
+
+            }
+
+            /**
+             * when 모두 등록되어있지 않은 상행역과 하행역을 등록하면
+             * then 예외가 발생한다.
+             */
+            @DisplayName("상행역과 하행역 모두 등록되어있지 않으면 예외 발생")
+            @Test
+            void 상행역_하행역_모두_미등록_예외 () {
+
+            }
+        }
+
     }
 
     /**

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -102,7 +102,12 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             @DisplayName("기존 역 사이 길이보다 크거나 같으면 예외 발생")
             @Test
             void 구간_길이_예외 () {
+                // when
+                ExtractableResponse<Response> 구간_생성 =
+                        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 삼성역, 100));
 
+                // then
+                assertThat(구간_생성.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
             }
 
             /**
@@ -179,6 +184,14 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
         params.put("distance", 6 + "");
+        return params;
+    }
+
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId + "");
+        params.put("downStationId", downStationId + "");
+        params.put("distance", distance + "");
         return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -12,8 +12,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static nextstep.subway.acceptance.LineSteps.*;
+import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("지하철 구간 관리 기능")
 class LineSectionAcceptanceTest extends AcceptanceTest {
@@ -21,6 +22,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
 
     private Long 강남역;
     private Long 양재역;
+    private Long 삼성역;
 
     /**
      * Given 지하철역과 노선 생성을 요청 하고
@@ -34,6 +36,9 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
 
         Map<String, String> lineCreateParams = createLineCreateParams(강남역, 양재역);
         신분당선 = 지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역));
+
+        삼성역 = 지하철역_생성_요청("삼성역").jsonPath().getLong("id");
     }
 
     @Nested
@@ -92,7 +97,12 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             @DisplayName("상행역과 하행역 모두 등록되어있으면 예외 발생")
             @Test
             void 상행역_하행역_모두_등록_예외 () {
+                // when
+                ExtractableResponse<Response> 구간_생성 =
+                        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 양재역));
 
+                // then
+                assertThat(구간_생성.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
             }
 
             /**

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -106,13 +106,22 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             }
 
             /**
+             * given 역을 등록하고
              * when 모두 등록되어있지 않은 상행역과 하행역을 등록하면
              * then 예외가 발생한다.
              */
             @DisplayName("상행역과 하행역 모두 등록되어있지 않으면 예외 발생")
             @Test
             void 상행역_하행역_모두_미등록_예외 () {
+                // given
+                Long 판교역 = 지하철역_생성_요청("판교역").jsonPath().getLong("id");
 
+                // when
+                ExtractableResponse<Response> 구간_생성 =
+                        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(삼성역, 판교역));
+
+                // then
+                assertThat(구간_생성.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
             }
         }
 

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -83,7 +83,12 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
             @DisplayName("역 사이에 새로운 역 등록")
             @Test
             void 역사이_새로운역_등록 () {
+                // when
+                ExtractableResponse<Response> response = 지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 삼성역));
 
+                // then
+                assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(강남역, 삼성역, 양재역);
             }
         }
 

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -1,28 +1,76 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.StationService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
 @ExtendWith(MockitoExtension.class)
-public class LineServiceMockTest {
+class LineServiceMockTest {
     @Mock
     private LineRepository lineRepository;
     @Mock
     private StationService stationService;
+    @InjectMocks
+    private LineService lineService;
 
+    private Station upStation;
+    private Station downStation;
+    private Line line;
+
+    @BeforeEach
+    void setUp() {
+        upStation = new Station("삼성역");
+        downStation = new Station("강남역");
+        line = new Line("분당선", "bg-yellow-600");
+    }
+
+    @DisplayName("구간 추가")
     @Test
     void addSection() {
         // given
-        // lineRepository, stationService stub 설정을 통해 초기값 셋팅
+        given(stationService.findById(upStation.getId())).willReturn(upStation);
+        given(stationService.findById(downStation.getId())).willReturn(downStation);
+        given(lineRepository.findById(anyLong())).willReturn(Optional.of(line));
+        SectionRequest sectionRequest = new SectionRequest(upStation.getId(), downStation.getId(), 10);
 
         // when
-        // lineService.addSection 호출
+        lineService.addSection(line.getId(), sectionRequest);
 
         // then
-        // line.findLineById 메서드를 통해 검증
+        verify(lineRepository).findById(line.getId());
+        assertThat(line.getSections()).hasSize(1);
+    }
+
+    @DisplayName("구간 삭제")
+    @Test
+    void deleteSection(){
+        //given
+        line.addSection(new Section(line, upStation, downStation, 10));
+        given(lineRepository.findById(anyLong())).willReturn(Optional.of(line));
+        given(stationService.findById(anyLong())).willReturn(downStation);
+
+        //when
+        lineService.deleteSection(1L, 2L);
+
+        //then
+        assertThat(line.getSections()).isEmpty();
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -1,12 +1,19 @@
 package nextstep.subway.unit;
 
 import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -19,15 +26,45 @@ public class LineServiceTest {
     @Autowired
     private LineService lineService;
 
+    private Station upStation;
+    private Station downStation;
+    private Line line;
+
+    @BeforeEach
+    void setUp() {
+        upStation = new Station("삼성역");
+        downStation = new Station("강남역");
+        line = new Line("분당선", "bg-yellow-600");
+    }
+
+    @DisplayName("구간 추가")
     @Test
     void addSection() {
         // given
-        // stationRepository와 lineRepository를 활용하여 초기값 셋팅
+        stationRepository.save(upStation);
+        stationRepository.save(downStation);
+        lineRepository.save(line);
 
         // when
-        // lineService.addSection 호출
+        lineService.addSection(line.getId(), new SectionRequest(upStation.getId(), downStation.getId(), 10));
 
         // then
-        // line.getSections 메서드를 통해 검증
+        assertThat(line.getSections()).hasSize(1);
+    }
+
+    @DisplayName("구간 삭제")
+    @Test
+    void deleteSection(){
+        //given
+        stationRepository.save(upStation);
+        stationRepository.save(downStation);
+        lineRepository.save(line);
+        lineService.addSection(line.getId(), new SectionRequest(upStation.getId(), downStation.getId(), 10));
+
+        //when
+        lineService.deleteSection(line.getId(), downStation.getId());
+
+        //then
+        assertThat(line.getSections()).isEmpty();
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -1,17 +1,57 @@
 package nextstep.subway.unit;
 
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 class LineTest {
+    @DisplayName("노선에 구간 추가")
     @Test
     void addSection() {
+        //given
+        Line line = new Line("분당선", "bg-yellow-600");
+        Section section = new Section(line, new Station("삼성역"), new Station("강남역"), 10);
+
+        //when
+        line.addSection(section);
+
+        //then
+        assertThat(line.getSections()).containsExactly(section);
     }
 
+    @DisplayName("노선의 모든 지하철역 조회")
     @Test
     void getStations() {
+        //given
+        Line line = new Line("분당선", "bg-yellow-600");
+        Station upStation = new Station("삼성역");
+        Station downStation = new Station("강남역");
+        line.addSection(new Section(line, upStation, downStation, 10));
+
+        //when
+        List<Station> stationList = line.getStations();
+
+        //then
+        assertThat(stationList).containsExactly(upStation, downStation);
     }
 
     @Test
     void removeSection() {
+        //given
+        Line line = new Line("분당선", "bg-yellow-600");
+        Section section = new Section(line, new Station("삼성역"), new Station("강남역"), 10);
+        line.addSection(section);
+
+        //when
+        line.removeSection(section);
+
+        //then
+        assertThat(line.getSections()).isEmpty();
     }
 }


### PR DESCRIPTION
안녕하세요!
진행 중에 문제가 있었는데 해결을 못해서 2단계 미션 진행이 늦어졌습니다.
1. 상행 종점 등록 테스트에서 지하철_노선에_지하철_구간_생성_요청 을 보낸 후 다시 조회해 왔을 때, 새로 추가된 구간이 첫번째로 조회가 안되는데 이유를 알 수 있을까요??
예를 들어) 강남-양재 -> +삼성-강남 -> 삼성-강남-양재 가 되어야하는데 계속 강남-양재-강남 으로 조회가되는 문제가 있었습니다. 
2.  실패 케이스에 대한 테스트에서 
assertThatIllegalArgumentException().isThrownBy(() ->
                        지하철_노선에_지하철_구간_생성_요청(신분당선, createSectionCreateParams(강남역, 삼성역, 100)));
를 사용해서 확인해주고 싶었는데 정상적으로 예외가 발생함에도 테스트가 성공하지 않는데 이유를 아시나요???